### PR TITLE
アクションの運用を改善

### DIFF
--- a/.github/workflows/notify_coins20.yml
+++ b/.github/workflows/notify_coins20.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          curl -XPOST \
+          curl -fsS -XPOST \
             -H 'Content-Type:application/json' \
             "${{ secrets.COINS20_DISCORD_WEBHOOK_URL }}" \
             -d @- << EOS

--- a/.github/workflows/notify_coins20.yml
+++ b/.github/workflows/notify_coins20.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'src/contents/**'
 
 jobs:
   discord_webhook:


### PR DESCRIPTION
coins20のdiscordに更新を通知するアクションを、運用が楽になるよう改善しました。

- `src/contents/`以下以外に反応しない
- Webhook発射に失敗したらCIが落ちる