### PR TITLE
カードのフォントサイズ変更

### DIFF
--- a/src/layouts/TopCard.js
+++ b/src/layouts/TopCard.js
@@ -38,10 +38,7 @@ const Link = styled.a`
 
 const Description = styled.p`
   color: ${Color.BLACK};
-  font-size: 1.3rem;
-  ${Media.MOBILE} {
-    font-size: 1.3rem;
-  }
+  font-size: 1.1rem;
 `;
 
 const Img = styled.img`


### PR DESCRIPTION
モバイルだと文字がでかすぎて飛び出す場合があるのでフォントサイズを小さくして解決します